### PR TITLE
Address focus trap review comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,6 +359,9 @@ window.addEventListener('DOMContentLoaded', function () {
       if (e.key === "Tab") {
         e.preventDefault();
         const items = modalFocusables;
+        if (items.length === 0) {
+          return;
+        }
         let index = items.indexOf(document.activeElement);
         if (e.shiftKey) {
           index = index <= 0 ? items.length - 1 : index - 1;
@@ -433,20 +436,20 @@ window.addEventListener('DOMContentLoaded', function () {
     previousFocus = document.activeElement;
       modalFocusables = Array.from(aboutModal.querySelectorAll(focusableSelector));
       aboutModal.addEventListener('keydown', trapFocus);
-      modalFocusables[0].focus();
+      if (modalFocusables.length > 0) {
+        modalFocusables[0].focus();
+      }
   });
   aboutClose.addEventListener("click", function () {
       aboutModal.removeEventListener('keydown', trapFocus);
     aboutModal.style.display = "none";
     if (previousFocus) previousFocus.focus();
   });
-  window.addEventListener('click', function (e) {
-    if (e.target === aboutModal) {
-      aboutModal.removeEventListener('keydown', trapFocus);
-      aboutModal.style.display = 'none';
-      if (previousFocus) previousFocus.focus();
-    }
-  });
+    window.addEventListener('click', function (e) {
+      if (e.target === aboutModal) {
+        aboutClose.click();
+      }
+    });
   document.getElementById('menu-move').addEventListener('click', function () {
     menuButtonMovable = !menuButtonMovable;
     menuButton.style.cursor = menuButtonMovable ? 'move' : 'pointer';


### PR DESCRIPTION
## Summary
- improve the focus-trap function by exiting early when no focusable items exist
- ensure About modal only focuses the first element when present
- reuse `aboutClose.click()` when clicking outside the About modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684af7e9dcf8832abbaa60ac6c336100